### PR TITLE
Refactor component display logic and add Radio Group component with demo

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -111,15 +111,35 @@ const Index = () => {
         <div className="max-w-6xl mx-auto">
           {filteredComponents.length > 0 ? (
             <div className="grid gap-8 md:grid-cols-1 lg:grid-cols-2">
-              {filteredComponents.map((component, index) => (
-                <div
-                  key={component.id}
-                  className="animate-fade-in"
-                  style={{ animationDelay: `${index * 0.1}s` }}
-                >
-                  <ComponentCard {...component} />
-                </div>
-              ))}
+              <div className="flex flex-col gap-8">
+
+              {filteredComponents.map((component, index) => {
+                if (index % 2 != 0) return null;
+                return (
+                  <div
+                    key={component.id}
+                    className="animate-fade-in"
+                    style={{ animationDelay: `${index * 0.1}s` }}
+                  >
+                    <ComponentCard {...component} />
+                  </div>
+                );
+              })}
+              </div>
+              <div className="flex flex-col gap-8">
+                {filteredComponents.map((component, index) => {
+                  if (index % 2 === 0) return null;
+                  return (
+                    <div
+                      key={component.id}
+                      className="animate-fade-in"
+                      style={{ animationDelay: `${index * 0.1}s` }}
+                    >
+                      <ComponentCard {...component} />
+                    </div>
+                  );
+                })}
+              </div>
             </div>
           ) : (
             <div className="text-center py-12">

--- a/src/data/components.tsx
+++ b/src/data/components.tsx
@@ -237,5 +237,44 @@ export function CalendarDemo() {
     />
   )
 }`
+    },{
+      id: "radio-group",
+      title: "Radio Group",
+      description: "A group of radio buttons that allows the user to select one option from a set.",
+      category: "Form",
+      preview: (
+          <div className="flex flex-col space-y-2">
+              <div className="flex items-center space-x-2">
+                  <input type="radio" id="option1" name="options" className="h-4 w-4 text-primary" />
+                  <label htmlFor="option1" className="text-sm">Option 1</label>
+              </div>  
+              <div className="flex items-center space-x-2">
+                  <input type="radio" id="option2" name="options" className="h-4 w-4 text-primary" />
+                  <label htmlFor="option2" className="text-sm">Option 2</label>
+              </div>
+              <div className="flex items-center space-x-2">
+                  <input type="radio" id="option3" name="options" className="h-4 w-4 text-primary" />
+                  <label htmlFor="option3" className="text-sm">Option 3</label>
+              </div>
+          </div>
+      ),
+      code: `export function RadioGroupDemo() {
+  return (
+    <div className="flex flex-col space-y-2"> 
+      <div className="flex items-center space-x-2">
+        <input type="radio" id="option1" name="options" />
+        <label htmlFor="option1">Option 1</label>
+      </div>
+      <div className="flex items-center space-x-2">
+        <input type="radio" id="option2" name="options" />
+        <label htmlFor="option2">Option 2</label>
+      </div>
+      <div className="flex items-center space-x-2">
+        <input type="radio" id="option3" name="options" />
+        <label htmlFor="option3">Option 3</label>
+      </div>
+    </div>
+  )
+}`
     }
 ];


### PR DESCRIPTION
This pull request introduces a new "Radio Group" component to the available components and updates the layout logic for displaying components in the main page. The layout change splits the component cards into two columns, alternating their display for a more balanced grid.

**Component additions:**

* Added a new `Radio Group` component to the components list in `components.tsx`, including a preview and code example.

**UI/layout improvements:**

* Updated the layout in `page.tsx` to render component cards in two vertical columns by splitting `filteredComponents` into even and odd indices, improving visual balance and readability.