### PR TITLE
Fix calendar hydration error by using deterministic date format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "lucide-react": "^0.544.0",
-        "next": "15.5.4",
+        "next": "^15.5.4",
         "next-themes": "^0.4.6",
         "react": "19.1.0",
         "react-day-picker": "^9.11.0",
@@ -1971,9 +1971,9 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.1.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
-      "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.0.tgz",
+      "integrity": "sha512-1LOH8xovvsKsCBq1wnT4ntDUdCJKmnEakhsuoUSy6ExlHCkGP2hqnatagYTgFk6oeL0VU31u7SNjunPN+GchtA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -1981,13 +1981,13 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.1.11",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.11.tgz",
-      "integrity": "sha512-3BKc/yGdNTYQVVw4idqHtSOcFsgGuBbMveKCOgF8wQ5QtrYOc3jDIlzg3jef04zcXFIHLelyGlj0T+BJ8+KN+w==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.0.tgz",
+      "integrity": "sha512-brtBs0MnE9SMx7px208g39lRmC5uHZs96caOJfTjFcYSLHNamvaSMfJNagChVNkup2SdtOxKX1FDBkRSJe1ZAg==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^19.0.0"
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/react-syntax-highlighter": {

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -190,7 +190,8 @@ function CalendarDayButton({
       ref={ref}
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString()}
+      // Use deterministic date format to fix hydration error
+      data-day={day.date.toISOString().split("T")[0]}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&


### PR DESCRIPTION
Resolves #77

This PR fixes the React hydration error on the calendar component caused by mismatched server/client date formats. 

- Changed date rendering to use a deterministic format (YYYY-MM-DD) instead of locale-dependent formatting.
- Ensures consistent display of dates on both server and client.
- Eliminates the server/client mismatch that was causing the red screen error.

Tested locally: ✅ Calendar now renders correctly without hydration warnings.


Before: 
<img width="1771" height="971" alt="Screenshot 2025-10-02 155816" src="https://github.com/user-attachments/assets/446bdbf6-d245-4175-931f-9de88f06152d" />

After:
<img width="1707" height="987" alt="Screenshot 2025-10-02 182828" src="https://github.com/user-attachments/assets/ee591223-bb7e-4d35-b501-702c5a8b5a6b" />
