### PR TITLE
Add skeleton loading placeholders for ComponentCard#27

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@types/react-syntax-highlighter": "^15.5.13",
-        "tailwindcss": "^4",
+        "tailwindcss": "^4.1.14",
         "tw-animate-css": "^1.4.0",
         "typescript": "^5"
       }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/react-syntax-highlighter": "^15.5.13",
-    "tailwindcss": "^4",
+    "tailwindcss": "^4.1.14",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5"
   }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -112,6 +112,45 @@
   --sidebar-ring: oklch(0.556 0 0);
 }
 
+/* --- Skeleton Shimmer Animation --- */
+
+/* Keyframes for the visual wave effect */
+@keyframes shimmer {
+  0% {
+    background-position: -400% 0;
+  }
+  100% {
+    background-position: 400% 0;
+  }
+}
+
+/* CSS Variables for Theme-Aware Colors */
+:root {
+  /* Light Theme Colors (e.g., matching a background of gray-50/100) */
+  --skeleton-bg-start: #e5e7eb; /* gray-200 */
+  --skeleton-bg-shimmer: #f3f4f6; /* gray-100 */
+}
+
+.dark {
+  /* Dark Theme Colors (e.g., matching a background of gray-900/800) */
+  --skeleton-bg-start: #374151; /* gray-700 */
+  --skeleton-bg-shimmer: #4b5563; /* gray-600 */
+}
+
+/* Base class applied to the skeleton element */
+.skeleton-shimmer {
+  /* Adjust color stops to be slightly wider for a smoother gradient */
+  background: linear-gradient(
+    90deg,
+    var(--skeleton-bg-start) 0%,
+    var(--skeleton-bg-shimmer) 20%,
+    var(--skeleton-bg-start) 40%,
+    var(--skeleton-bg-start) 100%
+  );
+  background-size: 200% 100%; /* Important for the movement effect */
+  animation: shimmer 1.5s infinite cubic-bezier(0.4, 0, 0.2, 1);
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;
@@ -166,6 +205,7 @@
     @apply gap-4 sm:gap-6 lg:gap-8;
   }
 
+  /* Responsive gap utilities */
   .gap-responsive-sm {
     @apply gap-2 sm:gap-3 lg:gap-4;
   }

--- a/src/components/ComponentCard.tsx
+++ b/src/components/ComponentCard.tsx
@@ -4,6 +4,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { CodeBlock } from "./CodeBlock";
 import { Eye, Code2, Info, ChevronDown, ChevronUp } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Skeleton} from "@/components/ui/skeleton";
 
 interface PropData {
     name: string;
@@ -22,6 +23,7 @@ interface ComponentCardProps {
     propsData?: PropData[];
     usageNotes?: string;
     installCommand?: string;
+    loading?: boolean;
 }
 
 export const ComponentCard = ({
@@ -32,37 +34,43 @@ export const ComponentCard = ({
     category,
     propsData,
     usageNotes,
-    installCommand
+    installCommand,
+    loading = false
 }: ComponentCardProps) => {
     const [activeTab, setActiveTab] = useState("preview");
     const [showDetails, setShowDetails] = useState(false);
 
     return (
         <Card className="overflow-hidden border-border bg-card/50 backdrop-blur-sm hover:shadow-lg transition-all duration-300">
-            {/* Header Section - Enhanced */}
             <div className="p-4 sm:p-5 lg:p-6 border-b border-border bg-gradient-to-br from-card to-card/50">
                 <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-3 mb-3">
                     <div className="flex-1">
                         <div className="flex flex-wrap items-center gap-2 mb-2">
-                            <h3 className="text-xl sm:text-2xl font-bold text-foreground">
-                                {title}
-                            </h3>
-                            {category && (
+                            {loading ? (
+                                <Skeleton width="200px" height="1.5rem" />
+                            ) : (
+                                <h3 className="text-xl sm:text-2xl font-bold text-foreground">{title}</h3>
+                            )}
+                            {!loading && category && (
                                 <span className="inline-flex items-center px-2.5 py-0.5 text-xs font-semibold rounded-full bg-primary/10 text-primary border border-primary/20">
                                     {category}
                                 </span>
                             )}
                         </div>
-                        <p className="text-sm text-muted-foreground leading-relaxed">
-                            {description}
-                        </p>
+                        {loading ? (
+                            <>
+                                <Skeleton width="100%" height="1rem" className="mb-1" />
+                                <Skeleton width="80%" height="1rem" />
+                            </>
+                        ) : (
+                            <p className="text-sm text-muted-foreground leading-relaxed">{description}</p>
+                        )}
                     </div>
                 </div>
 
-                {/* Quick Actions Row */}
                 {(propsData || installCommand) && (
                     <div className="flex flex-wrap items-center gap-2 mt-4 pt-4 border-t border-border/50">
-                        {propsData && (
+                        {!loading && propsData && (
                             <Button
                                 variant="outline"
                                 size="sm"
@@ -78,7 +86,8 @@ export const ComponentCard = ({
                                 )}
                             </Button>
                         )}
-                        {installCommand && (
+                        {loading && <Skeleton width="100px" height="1.5rem" />}
+                        {!loading && installCommand && (
                             <code className="px-3 py-1.5 text-xs font-mono bg-secondary/80 rounded-md border border-border">
                                 {installCommand}
                             </code>
@@ -87,8 +96,7 @@ export const ComponentCard = ({
                 )}
             </div>
 
-            {/* Expandable Props Documentation */}
-            {showDetails && propsData && (
+            {showDetails && propsData && !loading && (
                 <div className="px-4 sm:px-5 lg:px-6 py-4 border-b border-border bg-secondary/30 animate-in slide-in-from-top-2 duration-300">
                     <h4 className="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
                         <Info className="h-4 w-4 text-primary" />
@@ -101,26 +109,20 @@ export const ComponentCard = ({
                                 className="p-3 rounded-lg bg-card border border-border hover:border-primary/50 transition-colors"
                             >
                                 <div className="flex flex-wrap items-start gap-2 mb-1">
-                                    <code className="text-sm font-mono font-semibold text-primary">
-                                        {prop.name}
-                                    </code>
+                                    <code className="text-sm font-mono font-semibold text-primary">{prop.name}</code>
                                     {prop.required && (
                                         <span className="text-xs px-1.5 py-0.5 rounded bg-destructive/10 text-destructive font-medium">
                                             required
                                         </span>
                                     )}
-                                    <code className="text-xs font-mono text-muted-foreground">
-                                        {prop.type}
-                                    </code>
+                                    <code className="text-xs font-mono text-muted-foreground">{prop.type}</code>
                                     {prop.default && (
                                         <code className="text-xs font-mono text-muted-foreground ml-auto">
                                             default: {prop.default}
                                         </code>
                                     )}
                                 </div>
-                                <p className="text-xs text-muted-foreground leading-relaxed">
-                                    {prop.description}
-                                </p>
+                                <p className="text-xs text-muted-foreground leading-relaxed">{prop.description}</p>
                             </div>
                         ))}
                     </div>
@@ -134,9 +136,8 @@ export const ComponentCard = ({
                 </div>
             )}
 
-            {/* Tabs Section - Enhanced */}
             <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-                <div className="px-4 sm:px-5 lg:px-6 py-3 border-b border-border ">
+                <div className="px-4 sm:px-5 lg:px-6 py-3 border-b border-border">
                     <TabsList className="bg-gray-200 h-10 sm:h-11 p-1">
                         <TabsTrigger
                             value="preview"
@@ -155,19 +156,18 @@ export const ComponentCard = ({
                     </TabsList>
                 </div>
 
-                <TabsContent
-                    value="preview"
-                    className="p-4 sm:p-6 lg:p-8 min-h-[200px] sm:min-h-[240px]"
-                >
-                    <div className="w-full flex items-center justify-center p-8 rounded-xl border-2  border-border/50 bg-hover:border-border transition-colors">
-                        <div className="scale-90 sm:scale-95 lg:scale-100 origin-center">
-                            {preview}
+                <TabsContent value="preview" className="p-4 sm:p-6 lg:p-8 min-h-[200px] sm:min-h-[240px]">
+                    {loading ? (
+                        <Skeleton width="100%" height="150px" rounded="xl" />
+                    ) : (
+                        <div className="w-full flex items-center justify-center p-8 rounded-xl border-2 border-border/50 bg-hover:border-border transition-colors">
+                            <div className="scale-90 sm:scale-95 lg:scale-100 origin-center">{preview}</div>
                         </div>
-                    </div>
+                    )}
                 </TabsContent>
 
                 <TabsContent value="code" className="p-4 sm:p-5 lg:p-6">
-                    <CodeBlock code={code} />
+                    {loading ? <Skeleton width="100%" height="200px" /> : <CodeBlock code={code} />}
                 </TabsContent>
             </Tabs>
         </Card>

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import clsx from "clsx";
+
+interface SkeletonProps {
+  width?: string | number;
+  height?: string | number;
+  rounded?: boolean | string;
+  className?: string;
+}
+
+export const Skeleton: React.FC<SkeletonProps> = ({
+  width = "100%",
+  height = "1rem",
+  rounded = true,
+  className
+}) => {
+  return (
+    <div
+      style={{ width, height }}
+      className={clsx(
+        "bg-gray-300 dark:bg-gray-700 animate-pulse",
+        rounded ? "rounded-md" : "",
+        className
+      )}
+    />
+  );
+};


### PR DESCRIPTION
### Summary
This PR introduces a `loading` prop to the `ComponentCard` component, allowing skeleton placeholders to be displayed while data is loading. This improves the user experience by avoiding empty spaces or spinners.

### Changes
- Added a reusable `Skeleton` component with customizable width, height, and border radius.
- Updated `ComponentCard` to show skeletons for:
  - Title and category
  - Description text
  - Buttons / install command row
  - Preview area
  - Code tab
- Supports both light and dark themes.
- Maintains existing functionality when `loading={false}`.

### Usage
```tsx
<ComponentCard
  title="Button"
  description="A reusable button"
  preview={<Button>Click Me</Button>}
  code={`<Button>Click Me</Button>`}
  loading={true}
/>
