### PR TITLE
heme color picker UX fix + hydration-safe previews + anchor/link tweaks

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -264,7 +264,7 @@ const Index = () => {
       </section>
 
       {/* Components Grid Section */}
-      <section className="container mx-auto px-4 sm:px-6 lg:px-8 pb-20 sm:pb-24 lg:pb-32">
+      <section id="components" className="container mx-auto px-4 sm:px-6 lg:px-8 pb-20 sm:pb-24 lg:pb-32">
         {/* ... (The entire component grid display logic remains exactly the same) ... */}
         <div className="max-w-6xl mx-auto">
           {filteredComponents.length > 0 ? (
@@ -337,7 +337,13 @@ const Index = () => {
               <br />
               <span className="text-foreground">Components? </span>
         </h1>
-        <a href="" className="bg-zinc-900 px-6 rotate-[13deg] py-2 rounded-full -translate-9">
+        <a
+          href="https://github.com/fahimahammed/DevUI/blob/main/CONTRIBUTING.md"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Read the contributing guide on GitHub"
+          className="bg-zinc-900 px-6 rotate-[13deg] py-2 rounded-full -translate-9"
+        >
         <div className=" text-2xl text-white">
           Contribute it Here
         </div>

--- a/src/components/ComponentSnippetCard.tsx
+++ b/src/components/ComponentSnippetCard.tsx
@@ -313,10 +313,13 @@ export function ${title}Demo() {
               className={`w-full flex items-center justify-center p-8 rounded-xl border-2 border-dashed border-border/50 ${
                 isDark ? "bg-zinc-900/30" : "bg-zinc-50"
               } hover:border-border transition-colors`}
+              suppressHydrationWarning
             >
-              <div className="scale-[0.85] sm:scale-[0.9] lg:scale-100 origin-center max-w-full">
-                {preview}
-              </div>
+              {mounted ? (
+                <div className="scale-[0.85] sm:scale-[0.9] lg:scale-100 origin-center max-w-full">
+                  {preview}
+                </div>
+              ) : null}
             </div>
           )}
         </TabsContent>
@@ -324,12 +327,10 @@ export function ${title}Demo() {
           {loading ? (
             <Skeleton width="100%" height="200px" className={isDark ? "bg-zinc-700" : "bg-zinc-200"} />
           ) : (
-            <div>
-              <div className="mb-4 p-3 bg-secondary/30 rounded-lg border border-border">
-                <h4 className="text-sm font-medium text-foreground mb-2">Copy Code</h4>
-                <CodeBlock code={snippet} componentName={title} language="tsx" />
-              </div>
-              <div className="flex flex-wrap gap-2">
+            <div className="mb-4 p-3 bg-secondary/30 rounded-lg border border-border">
+              <h4 className="text-sm font-medium text-foreground mb-2">Copy Code</h4>
+              <CodeBlock code={snippet} componentName={title} language="tsx" />
+              <div className="flex flex-wrap gap-2 mt-4">
                 {variations.map((variant) => (
                   <Button
                     key={variant}

--- a/src/components/ui/ThemeColorPicker.tsx
+++ b/src/components/ui/ThemeColorPicker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Paintbrush } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
@@ -19,22 +19,62 @@ const STORAGE_KEY = "devui-theme-color";
 const ThemeColorPicker = () => {
   const [mounted, setMounted] = useState(false);
   const [activeColor, setActiveColor] = useState(themes[0].color);
+  const [open, setOpen] = useState(false);
+  const [alignLeft, setAlignLeft] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
 
   // UPDATED: This effect now loads the saved theme from localStorage on mount
   useEffect(() => {
     setMounted(true);
     const savedThemeName = localStorage.getItem(STORAGE_KEY);
-    const savedTheme = themes.find(t => t.name === savedThemeName);
+    const savedTheme = themes.find((t) => t.name === savedThemeName);
 
     if (savedTheme) {
       // If a theme was saved, apply it
       handleThemeChange(savedTheme, false); // Pass false to prevent re-saving
     } else {
       // Otherwise, get the default color from CSS
-      const currentColor = getComputedStyle(document.body).getPropertyValue('--primary').trim();
+      const currentColor = getComputedStyle(document.body)
+        .getPropertyValue("--primary")
+        .trim();
       setActiveColor(currentColor);
     }
   }, []);
+
+  // Close on outside click
+  useEffect(() => {
+    const onDown = (e: MouseEvent) => {
+      if (!open) return;
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (!open) return;
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  // When opening, detect viewport overflow and flip alignment if needed
+  useEffect(() => {
+    if (!open) return;
+    const el = menuRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const viewportRight = window.innerWidth - 8; // 8px safe padding
+    if (rect.right > viewportRight) {
+      setAlignLeft(true);
+    } else {
+      setAlignLeft(false);
+    }
+  }, [open]);
 
   // UPDATED: This function now saves the choice to localStorage
   const handleThemeChange = (theme: typeof themes[0], save = true) => {
@@ -57,22 +97,41 @@ const ThemeColorPicker = () => {
   }
 
   return (
-    <div className="fixed bottom-4 right-4 z-50">
-      <div className="group relative">
-        <div className="absolute bottom-full right-0 mb-4 grid grid-cols-5 gap-2 rounded-lg border bg-background/80 p-2 backdrop-blur-md opacity-0 transition-all duration-300 group-hover:opacity-100 group-focus-within:opacity-100">
+    <div className="fixed bottom-4 right-4 z-50" ref={containerRef}>
+      <div className="relative">
+        <div
+          ref={menuRef}
+          className={`absolute bottom-full ${alignLeft ? 'left-0 right-auto' : 'right-0 left-auto'} mb-3 flex items-center gap-2 rounded-xl border bg-background/90 p-2 backdrop-blur-md shadow-lg transition-all duration-200 origin-bottom-right overflow-visible min-w-max ${alignLeft ? 'translate-x-[4px]' : 'translate-x-[-4px]'}
+            ${open ? "opacity-100 scale-100 pointer-events-auto" : "opacity-0 scale-95 pointer-events-none"}`}
+          role="menu"
+          aria-label="Theme colors"
+          id="theme-color-menu"
+        >
           {themes.map((theme) => (
             <button
               key={theme.name}
               aria-label={`Switch to ${theme.name} theme`}
-              onClick={() => handleThemeChange(theme)}
-              className={`h-8 w-8 rounded-full border-2 transition-transform hover:scale-110 ${
+              onClick={() => {
+                handleThemeChange(theme);
+                setOpen(false);
+              }}
+              className={`h-8 w-8 rounded-full border-2 transition-transform hover:scale-110 focus-ring ${
                 activeColor === theme.color ? "border-foreground" : "border-transparent"
               }`}
               style={{ backgroundColor: theme.color }}
+              role="menuitem"
             />
           ))}
         </div>
-        <Button variant="outline" size="icon" className="h-12 w-12 rounded-full shadow-lg">
+        <Button
+          variant="outline"
+          size="icon"
+          className="h-12 w-12 rounded-full shadow-lg"
+          aria-haspopup="menu"
+          aria-expanded={open}
+          aria-controls="theme-color-menu"
+          onClick={() => setOpen((prev: boolean) => !prev)}
+        >
           <Paintbrush className="h-6 w-6" />
           <span className="sr-only">Change Theme Color</span>
         </Button>


### PR DESCRIPTION

## Description

Improves the `ThemeColorPicker` UX, ensures hydration-safe previews in `ComponentSnippetCard`, and fixes navigation/anchor issues on the home page.

* Color picker now opens on click, closes on outside click or Escape, and adjusts placement to prevent clipping. Accessibility attributes added.
* Preview cards render client-only to prevent hydration mismatch warnings.
* Home page navigation: added `id="components"` for anchor links and fixed the “Contribute it Here” link.

---


## Changes Made

* [x] Updated `src/components/ui/ThemeColorPicker.tsx` with improved click/close behavior, edge-aware placement, and accessibility attributes.
* [x] Updated `src/components/ComponentSnippetCard.tsx` to render previews client-only and suppress hydration warnings.
* [x] Updated `src/app/page.tsx` to fix anchor links and navigation issues.

---
Screenshots or GIFs

Before:
<img width="1908" height="855" alt="Before changes" src="https://github.com/user-attachments/assets/75f8fbb0-2209-4c57-98ad-085712d21bfb" />

After:
<img width="1885" height="874" alt="After changes" src="https://github.com/user-attachments/assets/093ca1b0-ee1b-4e6a-a017-f6af5404b5fa" />

