### PR TITLE
Add self-contained Spinner component and integrate into components data

### DIFF
--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export type SpinnerProps = React.HTMLAttributes<HTMLDivElement> & {
+  size?: "sm" | "md" | "lg";
+  label?: string;
+};
+
+export const Spinner = React.forwardRef<HTMLDivElement, SpinnerProps>(
+  ({ className, size = "md", label = "Loading", ...props }, ref) => {
+    const sizeClass =
+      size === "sm"
+        ? "h-4 w-4 border-2"
+        : size === "lg"
+        ? "h-8 w-8 border-2"
+        : "h-5 w-5 border-2";
+
+    return (
+      <div
+        ref={ref}
+        role="status"
+        aria-label={label}
+        className={cn(
+          "inline-block animate-spin rounded-full border-current border-t-transparent text-muted-foreground flex-shrink-0 align-middle",
+          sizeClass,
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+
+Spinner.displayName = "Spinner";
+export default Spinner;

--- a/src/data/components.tsx
+++ b/src/data/components.tsx
@@ -89,6 +89,8 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 
+import { Spinner } from "@/components/ui/spinner";
+
 export const componentsData = [
   {
     id: "button",
@@ -1960,6 +1962,40 @@ export function CollapsibleDemo() {
         description: "Transition duration in ms.",
         default: "220",
       },
+    ],
+  },
+  {
+  id: "spinner",
+  title: "Spinner",
+  description: "A small self-contained spinner used to indicate loading states.",
+  category: "Feedback",
+  preview: (
+    <div className="flex flex-col items-center gap-4">
+      <Spinner />
+      <div className="flex gap-3 items-center">
+        <Spinner size="sm" />
+        <Spinner size="md" />
+        <Spinner size="lg" />
+      </div>
+    </div>
+  ),
+  code: `import { Spinner } from "@/components/Spinner"
+
+export function SpinnerDemo() {
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <Spinner />
+      <div className="flex gap-3 items-center">
+        <Spinner size="sm" />
+        <Spinner size="md" />
+        <Spinner size="lg" />
+      </div>
+    </div>
+  )
+}`,
+  propsData: [
+      { name: "size", type: '"sm" | "md" | "lg"', description: "Size preset for the spinner.", default: "md" },
+      { name: "label", type: "string", description: "Accessible label for screen readers.", default: "Loading" },
     ],
   },
 ];


### PR DESCRIPTION
## Description
Added a new **self-contained Spinner component** to the UI library.  
The Spinner provides a simple, accessible loading indicator using pure CSS (no external icon dependencies).  
It aligns visually with other DevUI components and follows the same design, structure, and accessibility conventions.

## Related Issue
Fixes #205 

## Changes Made
- [x] Added `src/components/Spinner.tsx` — fully self-contained spinner component.
- [x] Integrated Spinner entry in `src/data/components.tsx` for documentation and preview.
- [x] Verified consistent sizing (`sm`, `md`, `lg`) and proper alignment in demos.
- [x] Ensured accessibility with `role="status"` and `aria-label`.

## Screenshots or GIFs (if applicable)
<img width="1912" height="953" alt="image" src="https://github.com/user-attachments/assets/9a9d11b3-ab6a-4901-82eb-169f44390af0" />

## Checklist
- [x] Only the necessary files are modified; no unrelated changes are included.
- [x] Follows clean code principles (readable, maintainable, minimal duplication).
- [x] All changes are clearly documented.
- [x] Code has been tested and visually verified in dev build.
- [x] No breaking changes are introduced to existing functionality.
- [x] All new and existing tests passed (if tests exist).

## Additional Notes
- The Spinner component does **not** depend on `lucide-react` or any prebuilt UI elements.  
- Built to match the repo’s “self-contained components” guideline.  
- Can be easily reused in loaders, Empty states, and buttons across the project.
