### PR TITLE
bug:DOMTokenList error

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,7 +34,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {/* ✅ Wrap everything in ThemeProvider */}
-        <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
+        <ThemeProvider attribute="class" defaultTheme="dark" enableSystem storageKey="devui-theme">
           <ThemeColorPicker />
           {children}
           <Toaster position="top-center" richColors />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import "./globals.css";
 import ThemeColorPicker from "@/components/ui/ThemeColorPicker";
 import { ThemeProvider } from "next-themes"; // ⬅️ import
 import { Toaster } from "@/components/ui/sonner";
+import Header from "@/components/Header";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -35,6 +36,7 @@ export default function RootLayout({
       >
         {/* ✅ Wrap everything in ThemeProvider */}
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem storageKey="devui-theme">
+          <Header />
           <ThemeColorPicker />
           {children}
           <Toaster position="top-center" richColors />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,6 @@ import "./globals.css";
 import ThemeColorPicker from "@/components/ui/ThemeColorPicker";
 import { ThemeProvider } from "next-themes"; // ⬅️ import
 import { Toaster } from "@/components/ui/sonner";
-import Header from "@/components/Header";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -36,7 +35,6 @@ export default function RootLayout({
       >
         {/* ✅ Wrap everything in ThemeProvider */}
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem storageKey="devui-theme">
-          <Header />
           <ThemeColorPicker />
           {children}
           <Toaster position="top-center" richColors />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -37,15 +37,9 @@ export default function RootLayout({
       >
         {/* ✅ Wrap everything in ThemeProvider */}
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem storageKey="devui-theme">
-          <ThemeColorPicker />
-          {children}
-          <Toaster position="top-center" richColors />
-          <BackToTopButton />
-        {/*  Wrap everything in ThemeProvider */}
-        <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
           <SearchProvider>
-            <ThemeColorPicker />
             <Header />
+            <ThemeColorPicker />
             {children}
             <Toaster position="top-center" richColors />
             <BackToTopButton />

--- a/src/components/ui/ThemeColorPicker.tsx
+++ b/src/components/ui/ThemeColorPicker.tsx
@@ -27,13 +27,29 @@ const ThemeColorPicker = () => {
   // Load saved theme from localStorage on mount
   useEffect(() => {
     setMounted(true);
+    
+    // Clean up any invalid theme names from next-themes localStorage
+    const nextThemesKey = 'devui-theme';
+    const nextThemesValue = localStorage.getItem(nextThemesKey);
+    if (nextThemesValue && nextThemesValue.includes(' ')) {
+      localStorage.removeItem(nextThemesKey);
+    }
+    
     const savedThemeName = localStorage.getItem(STORAGE_KEY);
-    const savedTheme = themes.find((t) => t.name === savedThemeName);
+    
+    // Validate theme name - remove any invalid characters
+    const cleanThemeName = savedThemeName?.replace(/[^a-zA-Z0-9-_]/g, '');
+    const savedTheme = themes.find((t) => t.name === cleanThemeName);
 
     if (savedTheme) {
       // If a theme was saved, apply it
       handleThemeChange(savedTheme, false); // Pass false to prevent re-saving
     } else {
+      // Clean up invalid theme names from localStorage
+      if (savedThemeName && savedThemeName !== cleanThemeName) {
+        localStorage.removeItem(STORAGE_KEY);
+      }
+      
       // Otherwise, get the default color from CSS
       const currentColor = getComputedStyle(document.body)
         .getPropertyValue("--primary")


### PR DESCRIPTION
Fixes: #223 

## Description
This PR fixes the DOMTokenList error that occurs when running npm run dev. The error was caused by theme names containing spaces (like "Default Theme") being passed to the next-themes library, which tries to add them as CSS class tokens. CSS class tokens cannot contain spaces or special characters, causing the application to fail to start properly.

## Changes Made
[x] Added custom storageKey="devui-theme" to ThemeProvider in src/app/layout.tsx
[x] Implemented theme name validation and cleanup logic in src/components/ui/ThemeColorPicker.tsx
[x] Added automatic removal of invalid theme names from localStorage on component mount
[x] Enhanced theme name validation using regex /[^a-zA-Z0-9-_]/g to remove invalid characters
[x] Added cleanup for both custom and next-themes localStorage keys

## Screenshots or GIFs (if applicable)
Before: 
<img width="740" height="400" alt="Screenshot 2025-10-18 at 2 47 21 PM" src="https://github.com/user-attachments/assets/49c94e1d-4558-47ee-ab7b-465720863ce1" />

After: 
<img width="1511" height="857" alt="Screenshot 2025-10-18 at 2 46 59 PM" src="https://github.com/user-attachments/assets/230d552d-a6d8-4932-94db-5ee3679bac90" />

